### PR TITLE
Fixed #8, Now accepting more characters in the chat filter.

### DIFF
--- a/js/content_script.js
+++ b/js/content_script.js
@@ -441,7 +441,7 @@ var GU = {
  'doChatAction': function(current)
     {
         var string = current.data;
-        var regexp = RegExp('^/([a-zA-Z]*)([ ]+([a-zA-Z0-9 \/~!@$%^*()\-+:<>?§þπτΔ&\.\?=]+))?$');
+        var regexp = RegExp('^/([a-zA-Z]*)([ ]+([a-zA-Z0-9 \\\\/~!@$%^*\\(\\)\\-+:<>§þπτΔ&\\.\\?=]+))?$');
         var regResult = regexp.exec(string);
         if (regResult != null)
         {


### PR DESCRIPTION
The chat filter now nolonger is having issues with characters:

()\/.?-

The issue was the Regex was being created in string format and the
\ characters used to escape the character class were being consumed
in the string parsing and then were not escaping the character class.
