### PR TITLE
Fixed #12, /fetchLast now supports a numerical parameter

### DIFF
--- a/js/content_script.js
+++ b/js/content_script.js
@@ -372,11 +372,35 @@ var GU = {
         if (songToPlay.length > 0)
             GS.Services.SWF.moveSongsTo([songToPlay[0].queueSongID], 1, true);
     },
- 'fetchLast': function(message, stringFilter)
+ 'fetchLast': function(message, input)
     {
+        var invert = false;
+        var songsToFetch = 1;
+        
+        var match = /(\!)?([\d]+)/.exec(input);
+        if (match) {
+            invert = match[1] == '!';
+            songsToFetch = parseInt(match[2]);
+        }
+        
         var songList = GS.Services.SWF.getCurrentQueue().songs;
-        if (songList.length > 2)
-            GS.Services.SWF.moveSongsTo([songList[songList.length - 1].queueSongID], 1, true);
+        
+        // Our song list needs to have enough songs past the current
+        if (songList.length <= (songsToFetch + 1)) {
+            console.log('Warning: Requested ' + songsToFetch + ' songs, but only ' + songList.length + ' were available.');
+            return;
+        } 
+        
+        var songIdsToFetch = [];
+        for(var i = songList.length - songsToFetch; i < songList.length; i++) {
+            songIdsToFetch.push(songList[i].queueSongID);
+        }
+        
+        if (invert) {
+            songIdsToFetch.reverse();
+        }
+        
+        GS.Services.SWF.moveSongsTo(songIdsToFetch, 1, true);
     },
  'shuffle': function()
     {


### PR DESCRIPTION
In addition to the requirements listed in the ticket there was
an obvious improvement that could be made. Once you pull more than
one the order matters.

/fetchLast 3
  This will grab the last 3 items in the queue in the exact order they
  appear and push them to the front.
/fetchLast !3
  This will grab the last 3 items in the queue and will flip thier order
  which essentially emulate three successive /fetchLast calls.
